### PR TITLE
Publish, validate, and process multiple messages at once

### DIFF
--- a/floodsub.go
+++ b/floodsub.go
@@ -75,7 +75,13 @@ func (fs *FloodSubRouter) Preprocess(from peer.ID, msgs []*Message) {}
 
 func (fs *FloodSubRouter) HandleRPC(rpc *RPC) {}
 
-func (fs *FloodSubRouter) Publish(msg *Message) {
+func (fs *FloodSubRouter) Publish(msgs []*Message) {
+	for _, msg := range msgs {
+		fs.publish(msg)
+	}
+}
+
+func (fs *FloodSubRouter) publish(msg *Message) {
 	from := msg.ReceivedFrom
 	topic := msg.GetTopic()
 

--- a/gossipsub.go
+++ b/gossipsub.go
@@ -1150,7 +1150,7 @@ func (gs *GossipSubRouter) PublishBatch(messages []*Message, opts *BatchPublishO
 	strategy := opts.Strategy
 	for _, msg := range messages {
 		msgID := gs.p.idGen.ID(msg)
-		for p, rpc := range gs.rpcs(msg) {
+		for p, rpc := range gs.rpcs([]*Message{msg}) {
 			strategy.AddRPC(p, msgID, rpc)
 		}
 	}
@@ -1160,47 +1160,94 @@ func (gs *GossipSubRouter) PublishBatch(messages []*Message, opts *BatchPublishO
 	}
 }
 
-func (gs *GossipSubRouter) Publish(msg *Message) {
-	for p, rpc := range gs.rpcs(msg) {
+func (gs *GossipSubRouter) Publish(msgs []*Message) {
+	for p, rpc := range gs.rpcs(msgs) {
 		gs.sendRPC(p, rpc, false)
 	}
 }
 
-func (gs *GossipSubRouter) rpcs(msg *Message) iter.Seq2[peer.ID, *RPC] {
+func (gs *GossipSubRouter) rpcs(messages []*Message) iter.Seq2[peer.ID, *RPC] {
 	return func(yield func(peer.ID, *RPC) bool) {
-		gs.mcache.Put(msg)
-
-		from := msg.ReceivedFrom
-		topic := msg.GetTopic()
-
-		tosend := make(map[peer.ID]struct{})
-
-		// any peers in the topic?
-		tmap, ok := gs.p.topics[topic]
-		if !ok {
-			return
+		for _, msg := range messages {
+			gs.mcache.Put(msg)
 		}
 
-		if gs.floodPublish && from == gs.p.host.ID() {
-			for p := range tmap {
-				_, direct := gs.direct[p]
-				if direct || gs.score.Score(p) >= gs.publishThreshold {
-					tosend[p] = struct{}{}
+		tosend := make(map[peer.ID]map[*Message]struct{})
+
+		appendTosend := func(p peer.ID, msgs ...*Message) {
+			if tosend[p] == nil {
+				tosend[p] = make(map[*Message]struct{})
+			}
+			for _, msg := range msgs {
+				tosend[p][msg] = struct{}{}
+			}
+		}
+
+		// mapping from topics to a list of locally published messages
+		localMsgMap := make(map[string][]*Message)
+		// mapping from topics to a list of messages supposed to be sent to mesh peers
+		meshMsgMap := make(map[string][]*Message)
+
+		for _, msg := range messages {
+			topic := msg.GetTopic()
+			if msg.ReceivedFrom == gs.p.host.ID() {
+				// save locally published messages
+				localMsgMap[topic] = append(localMsgMap[topic], msg)
+			} else {
+				// non-local messages are supposed to be sent to mesh peers
+				meshMsgMap[topic] = append(meshMsgMap[topic], msg)
+			}
+		}
+
+		if gs.floodPublish {
+			for topic, msgs := range localMsgMap {
+				// any peers in the topic?
+				tmap, ok := gs.p.topics[topic]
+				if !ok {
+					continue
+				}
+				// no need to send if there is no message
+				if len(msgs) == 0 {
+					continue
+				}
+
+				for p := range tmap {
+					_, direct := gs.direct[p]
+					if direct || gs.score.Score(p) >= gs.publishThreshold {
+						appendTosend(p, msgs...)
+					}
 				}
 			}
 		} else {
+			// if flood publish is not enabled, send locally published messages to mesh peers
+			for topic, msgs := range localMsgMap {
+				meshMsgMap[topic] = append(meshMsgMap[topic], msgs...)
+			}
+		}
+
+		for topic, msgs := range meshMsgMap {
+			// any peers in the topic?
+			tmap, ok := gs.p.topics[topic]
+			if !ok {
+				continue
+			}
+			// no need to send if there is no message
+			if len(msgs) == 0 {
+				continue
+			}
+
 			// direct peers
 			for p := range gs.direct {
 				_, inTopic := tmap[p]
 				if inTopic {
-					tosend[p] = struct{}{}
+					appendTosend(p, msgs...)
 				}
 			}
 
 			// floodsub peers
 			for p := range tmap {
 				if !gs.feature(GossipSubFeatureMesh, gs.peers[p]) && gs.score.Score(p) >= gs.publishThreshold {
-					tosend[p] = struct{}{}
+					appendTosend(p, msgs...)
 				}
 			}
 
@@ -1224,25 +1271,31 @@ func (gs *GossipSubRouter) rpcs(msg *Message) iter.Seq2[peer.ID, *RPC] {
 				gs.lastpub[topic] = time.Now().UnixNano()
 			}
 
-			csum := computeChecksum(gs.p.idGen.ID(msg))
-			for p := range gmap {
-				// Check if it has already received an IDONTWANT for the message.
-				// If so, don't send it to the peer
-				if _, ok := gs.unwanted[p][csum]; ok {
-					continue
+			for _, msg := range msgs {
+				csum := computeChecksum(gs.p.idGen.ID(msg))
+				for p := range gmap {
+					// Check if it has already received an IDONTWANT for the message.
+					// If so, don't send it to the peer
+					if _, ok := gs.unwanted[p][csum]; ok {
+						continue
+					}
+					appendTosend(p, msg)
 				}
-				tosend[p] = struct{}{}
 			}
 		}
 
-		out := rpcWithMessages(msg.Message)
-		for pid := range tosend {
-			if pid == from || pid == peer.ID(msg.GetFrom()) {
-				continue
+		for pid, mmap := range tosend {
+			var msgs []*pb.Message
+			for msg := range mmap {
+				if pid == msg.ReceivedFrom || pid == peer.ID(msg.GetFrom()) {
+					continue
+				}
+				msgs = append(msgs, msg.Message)
 			}
 
-			if !yield(pid, out) {
-				return
+			if len(msgs) > 0 {
+				out := rpcWithMessages(msgs...)
+				yield(pid, out)
 			}
 		}
 	}

--- a/randomsub.go
+++ b/randomsub.go
@@ -98,7 +98,13 @@ func (rs *RandomSubRouter) Preprocess(from peer.ID, msgs []*Message) {}
 
 func (rs *RandomSubRouter) HandleRPC(rpc *RPC) {}
 
-func (rs *RandomSubRouter) Publish(msg *Message) {
+func (rs *RandomSubRouter) Publish(msgs []*Message) {
+	for _, msg := range msgs {
+		rs.publish(msg)
+	}
+}
+
+func (rs *RandomSubRouter) publish(msg *Message) {
 	from := msg.ReceivedFrom
 
 	tosend := make(map[peer.ID]struct{})

--- a/validation.go
+++ b/validation.go
@@ -298,7 +298,16 @@ func (v *validation) validateWorker() {
 
 func (v *validation) sendMsgBlocking(msg *Message) error {
 	select {
-	case v.p.sendMsg <- msg:
+	case v.p.sendMsgs <- []*Message{msg}:
+		return nil
+	case <-v.p.ctx.Done():
+		return v.p.ctx.Err()
+	}
+}
+
+func (v *validation) sendMsgsBlocking(msgs []*Message) error {
+	select {
+	case v.p.sendMsgs <- msgs:
 		return nil
 	case <-v.p.ctx.Done():
 		return v.p.ctx.Err()


### PR DESCRIPTION
Addressing https://github.com/libp2p/go-libp2p-pubsub/issues/644

The main ideas are
(1) to drain the `incoming` queue and process all the messages in the queue at once. The process includes validating all the drained messages at once and forward them in a single RPC.
(2) to allow the publisher publishes multiple messages at once using `PublishMany` so that all the published messages can be batched inside a single RPC.